### PR TITLE
Adds publish to run functionality

### DIFF
--- a/build/test-rail.js
+++ b/build/test-rail.js
@@ -170,6 +170,21 @@ class TestRail {
     }
 
     /**
+     * Publishes results of execution of an automated test run to a specific run
+     * @param {[]} results
+     * @param {string} runId
+     * @param {callback} callback
+     */
+    publishToRun(results, runId, callback = undefined) {
+		console.log(`Results published to ${this.base}?/runs/view/${runId}`);
+		let body = this.addResultsForCases(runId, results);
+		// execute callback if specified
+		if (callback) {
+			callback(body);
+		}
+    }
+
+    /**
      * @param {number} runId
      * @param {{case_id, status_id, comment}[]} results
      * @return {*}

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "webdriver",
     "wdio",
     "wdio-reporter",
-	"testrail"
+    "testrail"
   ],
   "license": "MIT",
   "main": "./build/index",
@@ -60,5 +60,5 @@
   "scripts": {
     "generate-cases": "node scripts/generate-cases.js"
   },
-  "version": "0.0.3"
+  "version": "0.1.0"
 }


### PR DESCRIPTION
Adds a function which allows users to publish test results to a specific test run, instead of creating a new test run each time.